### PR TITLE
Fix how transform has to be registered

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,9 @@ The CMake plugin code is very similar to what exists here:
 
 # To test
 
-Cleaning your m2 repo is a good first step:
-
-    rm -rf ~/.m2/respository/*
-
 Publish the dependency just to see it:
 
-    ./gradlew :lib:publishToMavenLocal
+    ./gradlew :lib:publishAllPublicationsToExampleRepository
 
 Module metadata shows:
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -11,9 +11,11 @@ library {
     targetMachines.add(machines.linux.x86_64)
 }
 
-//repositories {
-//    maven {
-//        name 'example'
-//        url uri("${projectDir}/repo")
-//    }
-//}
+publishing {
+    repositories {
+        maven {
+            name 'example'
+            url uri("${buildDir}/repo")
+        }
+    }
+}

--- a/mock-consumer/build.gradle
+++ b/mock-consumer/build.gradle
@@ -4,10 +4,8 @@ plugins {
 
 version '1.0.0'
 
-import org.gradle.api.internal.artifacts.ArtifactAttributes;
-import org.gradle.api.internal.artifacts.transform.UnzipTransform;
-import static org.gradle.api.artifacts.type.ArtifactTypeDefinition.DIRECTORY_TYPE
-import static org.gradle.api.artifacts.type.ArtifactTypeDefinition.ZIP_TYPE
+def artifactType = Attribute.of('artifactType', String)
+def unzipped = Attribute.of('unzipped', Boolean)
 
 configurations {
     implementation {
@@ -18,12 +16,17 @@ configurations {
         canBeResolved = true
         extendsFrom implementation
         attributes.attribute Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.C_PLUS_PLUS_API)
-        attributes.attribute(ArtifactAttributes.ARTIFACT_FORMAT, ZIP_TYPE)
+        attributes.attribute(unzipped, true)
     }
 }
 
-afterEvaluate {
-    configurations.getByName('cppCompile').attributes.attribute(ArtifactAttributes.ARTIFACT_FORMAT, DIRECTORY_TYPE)
+dependencies {
+    attributesSchema {
+        attribute(unzipped)
+    }
+    artifactTypes.create("zip") {
+        attributes.attribute(unzipped, false)
+    }
 }
 
 tasks.register('someAction', Copy) {
@@ -34,15 +37,15 @@ tasks.register('someAction', Copy) {
 tasks.assemble.inputs.files tasks.someAction.outputs.files
 
 repositories {
-    mavenLocal()
+    maven {
+        url "../lib/build/repo"
+    }
 }
 
 dependencies {
     registerTransform(UnzipTransform, {
-        from.attribute ArtifactAttributes.ARTIFACT_FORMAT, ZIP_TYPE
-//        from.attribute Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.C_PLUS_PLUS_API)
-        to.attribute ArtifactAttributes.ARTIFACT_FORMAT, DIRECTORY_TYPE
-//        to.attribute Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.C_PLUS_PLUS_API)
+        from.attribute(unzipped, false).attribute(artifactType, "zip")
+        to.attribute(unzipped, true).attribute(artifactType, "zip")
     })
     implementation "com.company:lib:1.0.0"
 }


### PR DESCRIPTION
This PR shows how to properly register the extraction transform. In a nutshell:

- you _must not_ use internal types: it's a sign you're doing something wrong
- the configuration _must not_ specify artifact types, it must specify an attribute with semantics: here I define an attribute called `unzipped` of type `boolean`
- the configuration needs to specify a value for this new attribute, that is to say `true` in this case (we want to see "unzipped" artifacts)
- then you register the "default value" of the new attribute based on an _artifact type_. So when we'll see a `zip` file, we're saying "it's not unzipped"
- and finally you register the transform which explains how to go from (zip, false) to (zip, true)

